### PR TITLE
Add products search endpoint

### DIFF
--- a/src/routes/product.routes.mts
+++ b/src/routes/product.routes.mts
@@ -21,6 +21,28 @@ router.get("/", async (req, res, next) => {
   }
 });
 
+// GET /products/search
+router.get("/search", async (req, res, next) => {
+  try {
+    const cleanQuery = sanitize({ ...req.query } as Record<string, any>);
+    const result = await productService.searchProducts(cleanQuery as any);
+
+    if (result.count === 0) {
+      return next(
+        new EntityNotFoundError({
+          message: "Products Not Found",
+          code: "ERR_NF",
+          statusCode: 404,
+        })
+      );
+    }
+
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
 // GET /products/:id
 router.get("/:id", async (req, res, next) => {
   try {


### PR DESCRIPTION
## Summary
- add GET /api/v1/products/search
- search products by query term across category, name, and description
- keep pagination/fields behavior consistent with existing products list endpoint
- return 400 when query is missing and 404 when no matches are found

## Testing
- pnpm vitest run tests/integration/products.test.js (pass)

## Notes
- OpenAPI/Swagger update intentionally deferred for now as requested